### PR TITLE
[TEST] Add tests for global exception handling

### DIFF
--- a/backend/course-management/src/main/java/com/unityTest/courseManagement/RestExceptionHandler.java
+++ b/backend/course-management/src/main/java/com/unityTest/courseManagement/RestExceptionHandler.java
@@ -66,7 +66,9 @@ public class RestExceptionHandler extends ResponseEntityExceptionHandler {
             HttpStatus status,
             WebRequest request) {
         String message = ExceptionMsg.HTTP_MEDIA_TYPE_NOT_SUPPORTED(ex.getContentType(), ex.getSupportedMediaTypes());
-        return buildResponseEntity(new ApiError(HttpStatus.UNSUPPORTED_MEDIA_TYPE, message, ex, request));
+        ApiError error = new ApiError(HttpStatus.UNSUPPORTED_MEDIA_TYPE, ex.getLocalizedMessage(), ex, request);
+        error.setDebugMessage(message);
+        return buildResponseEntity(error);
     }
 
     /**
@@ -97,6 +99,7 @@ public class RestExceptionHandler extends ResponseEntityExceptionHandler {
 
     /**
      * Handle NoHandlerFoundException. Thrown when no handler exists for an endpoint.
+     * NOTE: NOT CURRENTLY IMPLEMENTED
      *
      * @param ex        NoHandlerFoundException
      * @param headers   HttpHeaders

--- a/backend/course-management/src/main/java/com/unityTest/courseManagement/constants/ExceptionMsg.java
+++ b/backend/course-management/src/main/java/com/unityTest/courseManagement/constants/ExceptionMsg.java
@@ -18,7 +18,7 @@ public class ExceptionMsg {
     public static final String ELEMENT_DOES_NOT_EXIST = "Element does not exist";
 
     public static String MISSING_REQUEST_PARAMETER(String name) {
-        return String.format("%s required parameter is missing", name);
+        return String.format("%s parameter is missing", name);
     }
 
     public static String HTTP_MEDIA_TYPE_NOT_SUPPORTED(MediaType type, List<MediaType> supportedTypes) {

--- a/backend/course-management/src/test/java/com/unityTest/courseManagement/TestUtils.java
+++ b/backend/course-management/src/test/java/com/unityTest/courseManagement/TestUtils.java
@@ -27,7 +27,8 @@ public class TestUtils {
     }
 
     public static MockHttpServletRequestBuilder delete(String url) {
-        return MockMvcRequestBuilders.delete(url);
+        return MockMvcRequestBuilders.delete(url)
+                .accept(MediaType.APPLICATION_JSON);
     }
 
     /**

--- a/backend/course-management/src/test/java/com/unityTest/courseManagement/rest/CourseApiTests.java
+++ b/backend/course-management/src/test/java/com/unityTest/courseManagement/rest/CourseApiTests.java
@@ -22,13 +22,12 @@ import org.springframework.test.web.servlet.MvcResult;
 import static com.unityTest.courseManagement.TestUtils.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.hasItem;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 /**
- * Implements Integration tests for Course API endpoints
+ * Implements component API tests for Course API endpoints
  */
 @AutoConfigureMockMvc
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)

--- a/backend/course-management/src/test/java/com/unityTest/courseManagement/rest/RestExceptionHandlerTests.java
+++ b/backend/course-management/src/test/java/com/unityTest/courseManagement/rest/RestExceptionHandlerTests.java
@@ -1,0 +1,132 @@
+package com.unityTest.courseManagement.rest;
+
+import com.unityTest.courseManagement.constants.ExceptionMsg;
+import com.unityTest.courseManagement.entity.Course;
+import com.unityTest.courseManagement.models.Term;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import static com.unityTest.courseManagement.TestUtils.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Implements testing of global exception handling for external REST APIs
+ */
+@AutoConfigureMockMvc
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_CLASS)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY)
+class RestExceptionHandlerTests {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    // Course endpoint
+    private String courseURI = "/course";
+
+    /**
+     * Test MissingServletRequestParameterException handler when request is missing required parameter.
+     */
+    @Test
+    void handleMissingServletRequestParameter_missingRequiredParam_BadRequestError() throws Exception {
+        // TODO Implement MissingServletRequestParameter test once an endpoint that can this error exists
+    }
+
+    /*
+        Test HttpMediaTypeNotSupported handler when request header Content-Type is set to include unsupported media type.
+     */
+    @Test
+    void handleHttpMediaTypeNotSupported_BadMediaType_UnsupportedMediaTypeError() throws Exception {
+        final Course course = new Course(0, "TEST", 1, Term.FALL, 2020);
+        final String uri = this.courseURI;
+
+        mockMvc.perform(MockMvcRequestBuilders.post(uri)
+                .content(asJsonString(course))
+                .contentType(MediaType.IMAGE_PNG)
+                .accept(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isUnsupportedMediaType())       // Expect a 415 status to be returned
+                .andExpect(jsonPath("$.code").value(HttpStatus.UNSUPPORTED_MEDIA_TYPE.value()))
+                .andExpect(jsonPath("$.status").value(HttpStatus.UNSUPPORTED_MEDIA_TYPE.name()))
+                .andExpect(jsonPath("$.path").value(uri));
+    }
+
+    /**
+     * Test HttpRequestMethodNotSupportException
+     */
+    @Test
+    void handleHttpRequestMethodNotSupported_InvalidHttpVerb_MethodNotAllowedError() throws Exception {
+        final String uri = this.courseURI;
+
+        // Call DELETE on /course endpoint. /course only supports POST and GET Http verbs
+        mockMvc.perform(delete(uri))
+                .andExpect(status().isMethodNotAllowed())       // Expect a 405 status to be returned
+                .andExpect(jsonPath("$.code").value(HttpStatus.METHOD_NOT_ALLOWED.value()))
+                .andExpect(jsonPath("$.status").value(HttpStatus.METHOD_NOT_ALLOWED.name()))
+                .andExpect(jsonPath("$.path").value(uri));
+    }
+
+    /**
+     * Test NoHandlerFoundException handler for request to unsupported path.
+     * TODO Add test once NoHandlerFoundException added to RestExceptionHanlder
+     */
+    void handleNotHandlerFoundException_InvalidPath_NotFoundError() throws Exception {
+        final String uri = "/invalidPath";      // Create some invalid path that does not exist
+
+        // Call DELETE on invalid path
+        mockMvc.perform(get(uri))
+                .andDo(print())
+                .andExpect(status().isNotFound())       // Expect a 404 status code
+                .andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.value()))
+                .andExpect(jsonPath("$.path").value(uri));
+    }
+
+    /**
+     * Test HttpMessageNotReadableException handler for request with malformed JSON body.
+     */
+    @Test
+    void handleHttpMessageNotReadable_MalformedJson_BadRequestError() throws Exception {
+        final String uri = this.courseURI;
+        final String malformedJsonBody = "{\n\t\"code\":\"Test\",";     // Create JSON missing closing bracket
+
+        // Call /course endpoint with malformed JSON body
+        mockMvc.perform(MockMvcRequestBuilders.post(uri)
+                .content(malformedJsonBody)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())     // Expect a 400 status to be returned
+                .andExpect(jsonPath("$.code").value(HttpStatus.BAD_REQUEST.value()))
+                .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.name()))
+                .andExpect(jsonPath("$.message").value(ExceptionMsg.MALFORMED_JSON_REQUEST))
+                .andExpect(jsonPath("$.path").value(uri));
+    }
+
+    /**
+     * Test PropertyReferenceException handler for request with pagination sorting referencing
+     * field not in object.
+     */
+    @Test
+    void handlePropertyReferenceException_BadPaginationSorting_NotFoundError() throws Exception {
+        final String uri = String.format("%s?sort=%s,asc", this.courseURI, "xx");
+
+        // Call GET endpoint and try to sort by property 'xx' which doesn't exist in course object
+        mockMvc.perform(get(uri))
+                .andExpect(status().isNotFound())       // Expect a 404 status to be returned
+                .andExpect(jsonPath("$.code").value(HttpStatus.NOT_FOUND.value()))
+                .andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.name()))
+                .andExpect(jsonPath("$.message").value(ExceptionMsg.PROPERTY_REFERENCE))
+                .andExpect(jsonPath("$.path").value(this.courseURI));
+    }
+}


### PR DESCRIPTION
## Overview
<!-- Give a brief overview of your changes. -->
Implements tests for the `RestExceptionHandler` class that handles api errors that can occur across multiple endpoints.

Closes #19 


This change is a
- [ ] Bug fix
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that will change exisiting functionality)
- [ ] Documentation update
- [x] Testing update

## Description
<!-- Describe your changes in detail -->
<!-- Enumerate all
 - Areas affected
 - Features added -->
- Add test class `RestExceptionHandlerTests` with tests to test methods from global Rest exception handler
- Updated a couple comments from rest handler
- Refactored a couple error messages to be more readable

## Motivation
<!-- Why was this change needed? -->
This adds test coverage for global handling of rest exceptions. It helps ensure the proper exceptions are being handled properly.

## Links
<!-- Add any relevant links here, issues, cards or other pull requests. -->
Linked card #19 

## How was this tested?
<!-- How were these changes tested? -->
Verified that `mvn test` runs without errors. Manual testing for setting up test cases.

## Todos
- [x] Ensure unit tests pass
- [ ] Update documentation for my changes (if necessary)
- [ ] Delete stale branch after merge